### PR TITLE
Import  `Iterable` class from `collections.abc` instead of `typing`

### DIFF
--- a/babylab/src/api.py
+++ b/babylab/src/api.py
@@ -5,10 +5,10 @@ Functions to interact with the REDCap API.
 """
 
 import os
-from typing import Iterable
+from collections import OrderedDict
+from collections.abc import Iterable
 import json
 import zipfile
-from collections import OrderedDict
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytz

--- a/babylab/src/utils.py
+++ b/babylab/src/utils.py
@@ -4,7 +4,7 @@ Util functions for the app.
 
 import os
 import shutil
-from typing import Iterable
+from collections.abc import Iterable
 from datetime import date, timedelta, datetime
 from functools import singledispatch
 from copy import deepcopy


### PR DESCRIPTION
Fixes #142.