### PR TITLE
Leave None values untouched by `fmt_labels`

### DIFF
--- a/babylab/utils.py
+++ b/babylab/utils.py
@@ -48,7 +48,7 @@ def _(x: dict, data_dict: dict) -> dict:
             if c in k:
                 y[k] = y[c] == "1"
         y[k] = y[k] if y[k] != "" else None
-    y = {k: (int(v) if k in INT_FIELDS else v) for k, v in y.items()}
+    y = {k: (int(v) if v and k in INT_FIELDS else v) for k, v in y.items()}
     return y
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,13 @@ from babylab import api, utils
 
 
 def test_fmt_labels_dict(data_dict):
-    x = {"source": "1", "sex": "2", "isdropout": "0", "age_now_months": "2"}
+    x = {
+        "source": "1",
+        "sex": "2",
+        "isdropout": "0",
+        "age_now_months": "2",
+        "birth_type": None,
+    }
     o = utils.fmt_labels(x, data_dict)
     assert isinstance(o, dict)
     assert all(k in o for k in x)
@@ -21,11 +27,18 @@ def test_fmt_labels_dict(data_dict):
     assert o["sex"] == "Male"
     assert o["isdropout"] is False
     assert o["age_now_months"] == 2
+    assert o["birth_type"] is None
 
 
 def test_fmt_labels_polars(data_dict):
     x = pl.DataFrame(
-        data={"source": "1", "sex": "2", "isdropout": "0", "age_now_months": "2"},
+        data={
+            "source": "1",
+            "sex": "2",
+            "isdropout": "0",
+            "age_now_months": "2",
+            "birth_type": None,
+        },
     )
     o = utils.fmt_labels(x, data_dict)
     assert isinstance(o, pl.DataFrame)
@@ -34,6 +47,7 @@ def test_fmt_labels_polars(data_dict):
     assert o["sex"][0] == "Male"
     assert not o["isdropout"][0]
     assert o["age_now_months"][0] == 2
+    assert o["birth_type"][0] is None
 
 
 def test_get_ppt_table(records_fixture: api.Records, data_dict: dict):


### PR DESCRIPTION
When None values were encountered in a dict, `fmt_labels` would raise an error. This PR leaves None values untouched and adds unit tests that make sure that's the case.